### PR TITLE
[2-vue] fix(historyview-4): 최근 검색어 삭제 시 검색창 노출 문제 수정

### DIFF
--- a/2-vue/src/app.js
+++ b/2-vue/src/app.js
@@ -53,8 +53,10 @@ new Vue({
     },
     onClickHistory(target, keyword) {
       const isNotRemove = !target.classList.contains('btn-remove')
-      if (isNotRemove) this.search(keyword)
-      this.query = keyword
+      if (isNotRemove) {
+        this.search(keyword)
+        this.query = keyword
+      }
     },
     fetchKeywords() {
       KeywordModel.list().then(data => {


### PR DESCRIPTION
### 요약
이번 PR은 최근 검색어가 삭제된 후에도 검색창이 잘못 표시되는 문제를 수정합니다.

### 상세 내용
- 최근 검색어 삭제 후 검색창이 여전히 나타나는 문제를 해결했습니다.
- 검색어의 존재 여부에 따라 검색창이 적절히 표시되도록 검색 처리 로직을 업데이트했습니다.

### 관련 이슈
- 이슈 번호: `historyview-4`

### 테스트
- 최근 검색어가 삭제된 후 검색창이 나타나지 않음을 확인했습니다.
- 검색어와 검색창 표시와 관련된 기능이 예상대로 작동하는지 검토했습니다.

### 추가 정보
- 이 수정 사항은 `[2-vue]` 브랜치에 적용됩니다.
- 변경 사항을 검토하시고 피드백을 주시기 바랍니다.

